### PR TITLE
refactor: 보안 그룹 구조 개선 및 Bastion EC2 구성 연동

### DIFF
--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -1,0 +1,15 @@
+variable "ami_id" {
+  type = string
+}
+
+variable "private_subnet_id" {
+  type = string
+}
+
+variable "security_group_id" {
+  type = string
+}
+
+variable "instance_profile_name" {
+  type = string
+}

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -3,7 +3,8 @@ resource "aws_eks_cluster" "this" {
   role_arn = var.eks_role_arn
 
   vpc_config {
-    subnet_ids = var.subnet_ids
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
   }
 
   enabled_cluster_log_types = ["api", "authenticator", "controllerManager", "scheduler"]

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -14,3 +14,8 @@ variable "node_role_arn" {
   type = string
 }
 
+variable "security_group_ids" {
+  description = "Security group IDs to associate with the EKS cluster"
+  type        = list(string)
+  default     = []
+}

--- a/modules/networking/security_group/outputs.tf
+++ b/modules/networking/security_group/outputs.tf
@@ -1,7 +1,15 @@
-output "app_sg_id" {
-  value = aws_security_group.app_sg.id
+output "eks_sg_id" {
+  value = aws_security_group.eks_sg.id
 }
 
 output "rds_sg_id" {
   value = aws_security_group.rds_sg.id
+}
+
+output "lambda_sg_id" {
+  value = aws_security_group.lambda_sg.id
+}
+
+output "bastion_sg_id" {
+  value = aws_security_group.bastion_sg.id
 }

--- a/modules/networking/security_group/security_groups.tf
+++ b/modules/networking/security_group/security_groups.tf
@@ -1,15 +1,23 @@
-# app_sg
-resource "aws_security_group" "app_sg" {
-  name        = "app-sg"
-  description = "Common app-level SG"
+# eks_sg
+resource "aws_security_group" "eks_sg" {
+  name        = "eks-sg"
+  description = "EKS node group security group"
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    cidr_blocks = ["0.0.0.0/0"]  # 모든 IP 허용
-    description = "Allow access from anywhere"
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    cidr_blocks     = ["0.0.0.0/0"]
+    description     = "From ALB"
+  }
+
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+    description     = "SSH from bastion (SSM Session Manager 등)"
   }
 
   egress {
@@ -20,22 +28,25 @@ resource "aws_security_group" "app_sg" {
   }
 
   tags = {
-    Name = "app-sg"
+    Name = "eks-sg"
   }
 }
 
 # rds_sg
 resource "aws_security_group" "rds_sg" {
   name        = "rds-sg"
-  description = "Allow DB access from app SG"
+  description = "RDS security group"
   vpc_id      = var.vpc_id
 
   ingress {
     from_port       = 3306
     to_port         = 3306
     protocol        = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]  # 모든 IP 허용
-    description = "Allow access from anywhere"
+    security_groups = [
+      aws_security_group.eks_sg.id,
+      aws_security_group.lambda_sg.id
+    ]
+    description = "MySQL from app"
   }
 
   egress {
@@ -47,5 +58,43 @@ resource "aws_security_group" "rds_sg" {
 
   tags = {
     Name = "rds-sg"
+  }
+}
+
+# bastion_sg
+resource "aws_security_group" "bastion_sg" {
+  name        = "bastion-sg"
+  description = "SSM Bastion EC2"
+  vpc_id      = var.vpc_id
+
+  # SSM을 통한 연결만 사용 (ingress 없음)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "bastion-sg"
+  }
+}
+
+# lambda_sg
+resource "aws_security_group" "lambda_sg" {
+  name        = "lambda-sg"
+  description = "Security group for Lambda functions accessing internal services"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic from Lambda"
+  }
+
+  tags = {
+    Name = "lambda-sg"
   }
 }


### PR DESCRIPTION
- eks_sg, rds_sg, lambda_sg, bastion_sg 보안 그룹 역할별로 분리
- main.tf에서 app_sg 참조 제거 및 목적별 SG로 대체
- EKS 클러스터에 security_group_ids 전달되도록 수정
- Bastion EC2 구성에 필요한 변수 연동 및 SG 변경 적용
- 모니터링 모듈과 알림 이메일 일시 주석 처리 (테스트 목적)