### PR TITLE
fix: SG description 필드에서 한글 제거 (ASCII 문자 제한 대응)

### DIFF
--- a/modules/networking/security_group/security_groups.tf
+++ b/modules/networking/security_group/security_groups.tf
@@ -17,7 +17,7 @@ resource "aws_security_group" "eks_sg" {
     to_port         = 22
     protocol        = "tcp"
     security_groups = [aws_security_group.bastion_sg.id]
-    description     = "SSH from bastion (SSM Session Manager 등)"
+    description     = "SSH from bastion (SSM Session Manager)"
   }
 
   egress {


### PR DESCRIPTION
- EKS 보안 그룹 ingress 설명란에서 한글 등 제거
- AWS의 보안 그룹 설명 필드가 ASCII 문자만 허용하는 문제 대응