### PR TITLE
fix: Launch Template에 SSH KeyPair 추가로 EKS 노드 생성 오류 수정

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -20,6 +20,8 @@ resource "aws_launch_template" "eks_nodes" {
   name_prefix   = "eks-node-"
   instance_type = "t3.medium"
 
+  key_name = "my-kp"
+
   network_interfaces {
     associate_public_ip_address = false
     security_groups             = var.security_group_ids


### PR DESCRIPTION
- EKS NodeGroup 생성 시 SSH KeyPair가 누락되어 노드 생성이 지연되는 문제를 해결. 
- Launch Template에 `key_name = "my-kp"` 설정을 추가하여 EC2 인스턴스가 정상적으로 생성되도록 수정.