### PR TITLE
revert: Launch Template 제거 및 기본 Node Group 방식으로 복원

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -15,27 +15,6 @@ resource "aws_eks_cluster" "this" {
   }
 }
 
-# Launch Template for NodeGroup
-resource "aws_launch_template" "eks_nodes" {
-  name_prefix   = "eks-node-"
-  instance_type = "t3.medium"
-
-  key_name = "my-kp"
-
-  network_interfaces {
-    associate_public_ip_address = false
-    security_groups             = var.security_group_ids
-  }
-
-  tag_specifications {
-    resource_type = "instance"
-    tags = {
-      Name = "${var.cluster_name}-node"
-    }
-  }
-}
-
-# EKS Node Group using Launch Template
 resource "aws_eks_node_group" "default" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = "${var.cluster_name}-ng"
@@ -48,9 +27,10 @@ resource "aws_eks_node_group" "default" {
     min_size     = 1
   }
 
-  launch_template {
-    id      = aws_launch_template.eks_nodes.id
-    version = "$Latest"
+  instance_types = ["t3.medium"]
+
+  remote_access {
+    ec2_ssh_key = "my-kp"
   }
 
   tags = {


### PR DESCRIPTION
- Launch Template 기반의 EKS Node Group 설정에서 과도한 지연 및 복잡성 문제 발생. 
- 기본 `instance_types` 및 `remote_access` 방식으로 되돌림.